### PR TITLE
When DataTables adds new rows to the table using AJAX, the JavaScript…

### DIFF
--- a/AdminPanel.Web/Views/Shared/Components/DataTable/Default.cshtml
+++ b/AdminPanel.Web/Views/Shared/Components/DataTable/Default.cshtml
@@ -274,6 +274,7 @@
             };
         }
 
+
         // Initialize the DataTable on the table element.
         var table = $('#@tableId').DataTable(tableConfig);
 


### PR DESCRIPTION
… that initializes these menus doesn't automatically run again for the new content. Therefore, the click triggers for the new menus are never activated.

The solution is to re-initialize the Metronic menu component every time DataTables draws the table. This can be done using the drawCallback option in the DataTables configuration.